### PR TITLE
Add AlgoNode Client as a free alternative to AlgoExplorer for testnet

### DIFF
--- a/src/Clients/AlgoNode.php
+++ b/src/Clients/AlgoNode.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Rootsoft\Algorand\Clients;
+
+/**
+ * AlgoNode REST client, see https://algonode.io/ for more details
+ */
+class AlgoNode
+{
+    /**
+     * The Algod API url for AlgoExplorer's MainNet.
+     */
+    public const MAINNET_ALGOD_API_URL = 'https://mainnet-api.algonode.cloud';
+
+    /**
+     * The Algod API url for AlgoExplorer's TestNet.
+     */
+    public const TESTNET_ALGOD_API_URL = 'https://testnet-api.algonode.cloud';
+
+    /**
+     * The Algod API url for AlgoExplorer's BetaNet.
+     */
+    public const BETANET_ALGOD_API_URL = 'https://betanet-api.algonode.cloud';
+
+    /**
+     * The Indexer API url for AlgoExplorer's MainNet.
+     */
+    public const MAINNET_INDEXER_API_URL = 'https://mainnet-idx.algonode.cloud';
+
+    /**
+     * The Indexer API url for AlgoExplorer's TestNet.
+     */
+    public const TESTNET_INDEXER_API_URL = 'https://testnet-idx.algonode.cloud';
+
+    /**
+     * The Indexer API url for AlgoExplorer's BetaNet.
+     */
+    public const BETANET_INDEXER_API_URL = 'https://betanet-idx.algonode.cloud';
+}


### PR DESCRIPTION
As of 3/1/22 AlgoExplorer disabled various GET requests for account, assets and application querying. AlgoNode still supports this.